### PR TITLE
Update deprecated selector

### DIFF
--- a/keymaps/space-tab.cson
+++ b/keymaps/space-tab.cson
@@ -1,3 +1,3 @@
-'.workspace':
+'atom-workspace':
   'ctrl-alt-]': 'space-tab:convert-to-tabs'
   'ctrl-alt-[': 'space-tab:convert-to-spaces'


### PR DESCRIPTION
> Use the `atom-workspace` tag instead of the `workspace` class.

Fixes #6