### PR TITLE
Replace deprecated API calls with new commands API

### DIFF
--- a/lib/space-tab.coffee
+++ b/lib/space-tab.coffee
@@ -1,7 +1,7 @@
 module.exports =
 	activate: (state) ->
-		atom.workspaceView.command "space-tab:convert-to-tabs", => @convertToTabs()
-		atom.workspaceView.command "space-tab:convert-to-spaces", => @convertToSpaces()
+		atom.commands.add 'atom-workspace' "space-tab:convert-to-tabs", => @convertToTabs()
+		atom.commands.add 'atom-workspace' "space-tab:convert-to-spaces", => @convertToSpaces()
 
 	convertToTabs: ->
 		editor = atom.workspace.activePaneItem


### PR DESCRIPTION
atom.workspaceView is no longer available. In most cases you will not need the view.

See https://atom.io/docs/api/v0.187.0/CommandRegistry