### PR TITLE
Correct typo in package's description

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./lib/space-tab",
   "version": "0.4.2",
   "private": true,
-  "description": "Coverts leading tabs to spaces or vice versa",
+  "description": "Converts leading tabs to spaces or vice versa",
   "repository": "https://github.com/jamesmacfie/space-tab",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This jumped out at me while I was browsing package search results in Atom. Couldn't help submitting a PR to fix it, sorry.
